### PR TITLE
[fix] fix home-page linking is not working

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -8,7 +8,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand page-scroll" href="{{ base_url | relative_url }}">Start Bootstrap</a>
+            <a class="navbar-brand page-scroll" href="{{ site.baseurl }}">Start Bootstrap</a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
- 原本的 `href="{{ base_url | relative_url }}"`

```
這個的意思是 這個網頁的 url
假設你連到 blog => href 就會等於 blog 的 url
假設你連到 page => href 就會等於 page 的 url
```

---

- 要改成 `href="{{ site.baseurl }}"` => 這個存取的值才是從 _config.yml 拿的

---
- google => jekyll base_url is not equal to config.yml
- 參考資料：https://stackoverflow.com/questions/22514104/cant-get-site-baseurl-to-work-in-jekyll